### PR TITLE
fix: prevent duplicate bashrc entries

### DIFF
--- a/scripts/setup-environment.sh
+++ b/scripts/setup-environment.sh
@@ -99,9 +99,12 @@ fi
 #------------------------------------------------------------------------------
 # 7) Persist env‐vars for future shells
 #------------------------------------------------------------------------------
-cat << 'EOF_BASHRC' >> ~/.bashrc
+if ! grep -q '^export DOTNET_ROOT=' ~/.bashrc || \
+   ! grep -q '\$HOME/.dotnet/tools' ~/.bashrc; then
+  cat <<'EOF_BASHRC' >> ~/.bashrc
 export DOTNET_ROOT="$HOME/.dotnet"
 export PATH="$PATH:$HOME/.dotnet:$HOME/.dotnet/tools:$HOME/.local/bin"
 EOF_BASHRC
+fi
 
 echo "All done!"


### PR DESCRIPTION
## Summary
- avoid appending DOTNET_ROOT and PATH multiple times

## Testing
- `dotnet test --no-build` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_685d6c32832c832da42896b64008eb60